### PR TITLE
phylo/insertion-metadata: Remove print statement from for loop

### DIFF
--- a/phylogenetic/scripts/insertion-metadata.py
+++ b/phylogenetic/scripts/insertion-metadata.py
@@ -32,7 +32,6 @@ def add_insertions(subtype, build, metadata, alignedinsertions, metadata_inserti
             has_insertion = any(len(str(row[col])) > 30 for col in column_with_insertion)
             if has_insertion:
                 index_with_insertion.append(index)
-            print(index_with_insertion)
         metadatadf['insertion'] = metadatadf.index.isin(index_with_insertion)
         metadatadf.to_csv(metadata_insertion, sep='\t', index= "accession")
 
@@ -52,4 +51,3 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     add_insertions(args.subtype, args.build, args.metadata, args.aligned_insertions, args.metadata_insertion)
-


### PR DESCRIPTION
## Description of proposed changes

Previously, the script printed out `index_with_insertion` within a for loop,  resulting in hundreds of lines in the logs that was just building up the same list.  This looks like a debugging print statement added during development that can be  removed entirely.

Resolves https://github.com/nextstrain/hmpv/issues/8

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
