### PR TITLE
fix(nextclade): rename deprecated schema fields

### DIFF
--- a/nextclade/resources/pathogen.json
+++ b/nextclade/resources/pathogen.json
@@ -56,7 +56,7 @@
     "frameShifts": {
       "enabled": true,
       "scoreWeight": 10,
-      "ignoreFrameShifts": [
+      "ignoredFrameShifts": [
         {
           "codonRange": {
             "begin": 206,
@@ -80,7 +80,7 @@
     "reference accession": "NC_039199",
     "reference name": "hMPV/00-1"
   },
-  "geneOrderPreference": [
+  "cdsOrderPreference": [
     "N",
     "P",
     "M",


### PR DESCRIPTION
Rename deprecated field names in `nextclade/resources/pathogen.json` to their current schema names.

| Old field | New field | Impact |
|-----------|-----------|--------|
| `qc.frameShifts.ignoreFrameShifts` | `ignoredFrameShifts` | G gene frame shift exclusion (codons 206-224) was not applied |
| `geneOrderPreference` | `cdsOrderPreference` | CDS display used default order instead of N, P, M, F, M2, SH, G, L |

Both old names are silently ignored by Nextclade, so these settings had no effect.

- [x] Rename `ignoreFrameShifts` to `ignoredFrameShifts`
- [x] Rename `geneOrderPreference` to `cdsOrderPreference`

> :warning: The existing dataset in `nextclade_data` is already patched in nextstrain/nextclade_data#420, so no immediate resubmission is needed. But without this upstream fix, the deprecated names will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the current field names (`FrameShiftsConfig.ignoredFrameShifts`, `cdsOrderPreference`).

1. Related to: nextstrain/nextclade_data#420